### PR TITLE
Move templates to ekara section

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -40,8 +40,6 @@ type (
 		Hooks EnvironmentHooks `yaml:",omitempty"`
 		// The global volumes of the environment
 		Volumes GlobalVolumes `yaml:",omitempty"`
-		// Templates contains the templates defined into a descriptor
-		Templates Patterns `yaml:",omitempty"`
 
 		parcels []Parcel
 	}
@@ -75,7 +73,6 @@ func CreateEnvironment(location string, yamlEnv yamlEnvironment, holder string) 
 	env.Name = yamlEnv.Name
 	env.Qualifier = yamlEnv.Qualifier
 	env.Description = yamlEnv.Description
-	env.Templates = createPatterns(env, env.location.appendPath("templates_patterns"), yamlEnv.Templates)
 	env.Vars = CreateParameters(yamlEnv.yamlVars.Vars)
 
 	env.Tasks, err = createTasks(env, env.location.appendPath("tasks"), &yamlEnv)
@@ -133,8 +130,8 @@ func (r *Environment) Customize(from Component, with *Environment) error {
 
 	// We don't want to customize the templates defined into the environment
 	// But instead we want to keep them into the component
-	r.Platform().KeepTemplates(from, with.Templates)
-	with.Templates = Patterns{}
+	r.Platform().KeepTemplates(from, with.ekara.Templates)
+	with.ekara.Templates = Patterns{}
 
 	// basic informations (name, qualifier, description) are only accepted once if the are not already defined
 	if r.Name == "" {

--- a/environment_test.go
+++ b/environment_test.go
@@ -45,8 +45,8 @@ func assertEnv(t *testing.T, env *Environment) {
 	}
 
 	// Templates
-	assert.NotNil(t, env.Templates)
-	templates := env.Templates
+	assert.NotNil(t, env.ekara.Templates)
+	templates := env.ekara.Templates
 	tC := templates.Content
 	if assert.Equal(t, len(tC), 2) {
 		assert.Contains(t, tC, "environment/*/*.yaml")

--- a/generate/engine_api.json
+++ b/generate/engine_api.json
@@ -28,9 +28,7 @@
             {"name":"HasCreateHooks",  "custom": {"returns":"bool", "impl":"r.h.Hooks.Create.HasTasks()"}, "doc":"returns true if the environment has hooks while creating"},
             {"name":"HasInstallHooks",  "custom": {"returns":"bool", "impl":"r.h.Hooks.Install.HasTasks()"}, "doc":"returns true if the environment has hooks while installing"},
             {"name":"HasDeployHooks",  "custom": {"returns":"bool", "impl":"r.h.Hooks.Deploy.HasTasks()"}, "doc":"returns true if the environment has hooks while deploying"},
-            {"name":"HasDestroyHooks",  "custom": {"returns":"bool", "impl":"r.h.Hooks.Destroy.HasTasks()"}, "doc":"returns true if the environment has hooks while destroying"},
-            {"name":"HasTemplates", "custom": {"returns":"bool", "impl":"len(r.h.Templates.Content) > 0"}, "doc":"returns true if the environment has defined templates"},
-            {"name":"Templates", "custom": {"returns":"[]string", "impl":"r.h.Templates.Content"}, "doc":"returns the environment templates"}
+            {"name":"HasDestroyHooks",  "custom": {"returns":"bool", "impl":"r.h.Hooks.Destroy.HasTasks()"}, "doc":"returns true if the environment has hooks while destroying"}
         ]
     },
     {  
@@ -151,7 +149,9 @@
         "methods":[  
             {"name":"Base", "interface":{"name":"TBase", "attribute":"Base" }, "doc":"returns the base location of the platform"},
             {"name":"Parent", "interface":{"name":"TComponent", "attribute":"Parent"}, "doc":"returns the parent used by the platform"},
-            {"name":"HasComponents",  "custom": {"returns":"bool", "impl":"len(r.h.Components) > 0"}, "doc":"returns true if the platform has components"}
+            {"name":"HasComponents",  "custom": {"returns":"bool", "impl":"len(r.h.Components) > 0"}, "doc":"returns true if the platform has components"},
+            {"name":"HasTemplates", "custom": {"returns":"bool", "impl":"len(r.h.Templates.Content) > 0"}, "doc":"returns true if the environment has defined templates"},
+            {"name":"Templates", "custom": {"returns":"[]string", "impl":"r.h.Templates.Content"}, "doc":"returns the environment templates"}
         ]
     },
     {  

--- a/generatedTEnvironment.go
+++ b/generatedTEnvironment.go
@@ -162,13 +162,3 @@ func (r TEnvironmentOnEnvironmentHolder) HasDeployHooks() bool {
 func (r TEnvironmentOnEnvironmentHolder) HasDestroyHooks() bool {
 	return r.h.Hooks.Destroy.HasTasks()
 }
-
-//HasTemplates returns true if the environment has defined templates
-func (r TEnvironmentOnEnvironmentHolder) HasTemplates() bool {
-	return len(r.h.Templates.Content) > 0
-}
-
-//Templates returns the environment templates
-func (r TEnvironmentOnEnvironmentHolder) Templates() []string {
-	return r.h.Templates.Content
-}

--- a/generatedTPlatform.go
+++ b/generatedTPlatform.go
@@ -42,3 +42,13 @@ func (r TPlatformOnPlatformHolder) Parent() TComponent {
 func (r TPlatformOnPlatformHolder) HasComponents() bool {
 	return len(r.h.Components) > 0
 }
+
+//HasTemplates returns true if the environment has defined templates
+func (r TPlatformOnPlatformHolder) HasTemplates() bool {
+	return len(r.h.Templates.Content) > 0
+}
+
+//Templates returns the environment templates
+func (r TPlatformOnPlatformHolder) Templates() []string {
+	return r.h.Templates.Content
+}

--- a/pattern.go
+++ b/pattern.go
@@ -25,7 +25,7 @@ func (r Patterns) inherit(parent Patterns) Patterns {
 	return dst
 }
 
-func createPatterns(env *Environment, location DescriptorLocation, paths []string) Patterns {
+func createPatterns(paths []string) Patterns {
 	res := Patterns{}
 	for _, v := range paths {
 		res.Content = append(res.Content, v)

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCreatePatterns(t *testing.T) {
 	paths := []string{"my_path1", "my_path2", "my_path3"}
-	p := createPatterns(&Environment{}, DescriptorLocation{Path: "location"}, paths)
+	p := createPatterns(paths)
 	assert.NotNil(t, p)
 	if assert.Equal(t, len(paths), len(p.Content)) {
 		for _, v := range p.Content {
@@ -20,10 +20,10 @@ func TestCreatePatterns(t *testing.T) {
 func TestPatternsInherits(t *testing.T) {
 
 	paths := []string{"path1", "path2"}
-	p := createPatterns(&Environment{}, DescriptorLocation{Path: "location"}, paths)
+	p := createPatterns(paths)
 
 	pathsOther := []string{"path1", "path3", "path4"}
-	o := createPatterns(&Environment{}, DescriptorLocation{Path: "location"}, pathsOther)
+	o := createPatterns(pathsOther)
 
 	res := p.inherit(o)
 

--- a/platform.go
+++ b/platform.go
@@ -10,6 +10,7 @@ type Platform struct {
 	Parent     Parent
 	HasParent  bool
 	Components map[string]Component
+	Templates  Patterns
 }
 
 func createPlatform(yamlEkara yamlEkara) (Platform, error) {
@@ -28,6 +29,9 @@ func createPlatform(yamlEkara yamlEkara) (Platform, error) {
 	}
 	p.HasParent = hasParent
 	p.Parent = parent
+
+	// Store templates in the environment
+	p.Templates = createPatterns(yamlEkara.Templates)
 
 	// Create other components of the environment
 	components := map[string]Component{}

--- a/tInterfaceGenerated.go
+++ b/tInterfaceGenerated.go
@@ -60,10 +60,6 @@ type TEnvironment interface {
 	HasDeployHooks() bool
 	//HasDestroyHooks returns true if the environment has hooks while destroying
 	HasDestroyHooks() bool
-	//HasTemplates returns true if the environment has defined templates
-	HasTemplates() bool
-	//Templates returns the environment templates
-	Templates() []string
 }
 
 // TOrchestrator is a read only orchestrator
@@ -196,6 +192,10 @@ type TPlatform interface {
 	Parent() TComponent
 	//HasComponents returns true if the platform has components
 	HasComponents() bool
+	//HasTemplates returns true if the environment has defined templates
+	HasTemplates() bool
+	//Templates returns the environment templates
+	Templates() []string
 }
 
 // TBase is a read only base location

--- a/testdata/yaml/complete.yaml
+++ b/testdata/yaml/complete.yaml
@@ -33,15 +33,13 @@ ekara:
     task3:
       repository: some-org/task21
       ref: 1.2.3
-
+  templates:
+    - "environment/*/*.yaml"
+    - "environment/*.yml"
 
 vars:
   global_var_key1: global_var_val1 
   global_var_key2: global_var_val2 
-
-templates:
-  - "environment/*/*.yaml"
-  - "environment/*.yml"
 
 tasks:
   task1:

--- a/yaml.go
+++ b/yaml.go
@@ -114,6 +114,8 @@ type (
 		Base       string `yaml:",omitempty"`
 		Parent     yamlComponent
 		Components map[string]yamlComponent
+		// The list of path patterns where to apply the template mechanism
+		Templates []string `yaml:"templates"`
 	}
 
 	yamlNode struct {
@@ -149,9 +151,6 @@ type (
 
 		// The descriptor variables
 		yamlVars `yaml:",inline"`
-
-		// The list of path patterns where to apply the template mechanism
-		Templates []string `yaml:"templates"`
 
 		// Tasks which can be run on the created environment
 		Tasks map[string]struct {


### PR DESCRIPTION
This PR moves the templates section to the ekara section.
It seems cleaner to group component settings inside the ekara section.